### PR TITLE
feat: Actions for validating and uploading lexicon

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -3,6 +3,8 @@ name: Deploy to ECS
 on:
   push:
     branches: ["main"]
+    paths:
+      - "**.pls"
 
 jobs:
   upload:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,4 +1,4 @@
-name: Deploy to ECS
+name: Upload Lexicon
 
 on:
   push:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,0 +1,21 @@
+name: Deploy to ECS
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Upload lexicon
+        run: |
+          aws polly put-lexicon --name mbtalexicon --content file://${{ github.workspace }}/mbtalexicon.pls

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,9 +20,8 @@ jobs:
       - name: Validate lexicon
         run: |
           aws polly put-lexicon --name mbtalexiconvalidate --content file://${{ github.workspace }}/mbtalexicon.pls
-          echo "response=$?" >> $GITHUB_OUTPUT
-        id: upload_lexicon
-      - name: Delete lexicon
-        run: |
-          aws polly delte-lexicon --name mbtalexiconvalidate
-        if: steps.upload_lexicon.outputs.response == 0
+          if [ $(echo $?) = 0 ]; then
+            aws polly delte-lexicon --name mbtalexiconvalidate
+          else
+            exit 1
+          fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,37 @@
+name: Validate Lexicon
+
+on:
+  pull_request:
+    paths:
+      - "**.pls"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Validate lexicon
+        run: |
+          aws polly put-lexicon --name mbtalexiconvalidate --content file://${{ github.workspace }}/mbtalexicon.pls
+  cleanup:
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Validate lexicon
+        run: |
+          aws polly delete-lexicon --name mbtalexiconvalidate

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,18 +20,9 @@ jobs:
       - name: Validate lexicon
         run: |
           aws polly put-lexicon --name mbtalexiconvalidate --content file://${{ github.workspace }}/mbtalexicon.pls
-  cleanup:
-    needs: validate
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
-      - name: Validate lexicon
+          echo "response=$?" >> $GITHUB_OUTPUT
+        id: upload_lexicon
+      - name: Delete lexicon
         run: |
-          aws polly delete-lexicon --name mbtalexiconvalidate
+          aws polly delte-lexicon --name mbtalexiconvalidate
+        if: steps.upload_lexicon.outputs.response == 0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,6 +20,3 @@ jobs:
       - name: Validate lexicon
         run: |
           aws polly put-lexicon --name mbtalexiconvalidate --content file://${{ github.workspace }}/mbtalexicon.pls
-          if [ $? -ne 0 ]; then
-            exit 1
-          fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,8 +20,6 @@ jobs:
       - name: Validate lexicon
         run: |
           aws polly put-lexicon --name mbtalexiconvalidate --content file://${{ github.workspace }}/mbtalexicon.pls
-          if [ $(echo $?) = 0 ]; then
-            aws polly delte-lexicon --name mbtalexiconvalidate
-          else
+          if [ $? -ne 0 ]; then
             exit 1
           fi


### PR DESCRIPTION
Added a couple of actions. One validates the lexicon on PR creation by uploading it under a different name and checking the response. On success, we delete the lexicon. The other uploads the lexicon on merge.