### PR TITLE
Organize, audit, and comment existing entries

### DIFF
--- a/mbtalexicon.pls
+++ b/mbtalexicon.pls
@@ -5,6 +5,43 @@
       xsi:schemaLocation="http://www.w3.org/2005/01/pronunciation-lexicon
         http://www.w3.org/TR/2007/CR-pronunciation-lexicon-20071212/pls.xsd"
       alphabet="ipa" xml:lang="en-US">
+
+  <!--=== Phonemes ===-->
+
+  <lexeme>
+    <grapheme>Amory</grapheme>
+    <phoneme>ˈeɪməɹi</phoneme>
+  </lexeme>
+  <lexeme>
+    <grapheme>Avon</grapheme>
+    <phoneme>eɪvan</phoneme>
+  </lexeme>
+  <lexeme>
+    <!-- Corrects "Central Lavenue" pronunciation -->
+    <grapheme>Central Avenue</grapheme>
+    <phoneme>ˈsɛntɹl ˈævənu</phoneme>
+  </lexeme>
+  <lexeme>
+    <grapheme>Chiswick</grapheme>
+    <phoneme>tʃɪz wɪk</phoneme>
+  </lexeme>
+  <lexeme>
+    <!-- Previous pronunciation sounded like "Fen-a-way" :thinkies: -->
+    <grapheme>Fenway</grapheme>
+    <phoneme>ˈfɛnweɪ</phoneme>
+  </lexeme>
+  <lexeme>
+    <grapheme>Fine Arts</grapheme>
+    <phoneme>faɪn aɹts</phoneme>
+  </lexeme>
+  <lexeme>
+    <grapheme>Hyannis</grapheme>
+    <phoneme>haɪ ˈænɪs</phoneme>
+  </lexeme>
+  <lexeme>
+    <grapheme>LaGrange</grapheme>
+    <phoneme>ˌləˈgɹanʒ</phoneme>
+  </lexeme>
   <lexeme>
     <grapheme>Lechmere</grapheme>
     <phoneme>litʃ miɹ</phoneme>
@@ -13,6 +50,76 @@
     <grapheme>Mattapan</grapheme>
     <phoneme>mæɾ əˈpæn</phoneme>
   </lexeme>
+  <lexeme>
+    <!-- Moves emphasis to "Pack-" from "-ard" -->
+    <grapheme>Packard</grapheme>
+    <phoneme>ˈpækəɹd</phoneme>
+  </lexeme>
+  <lexeme>
+    <grapheme>Peabody</grapheme>
+    <phoneme>ˈpibədi</phoneme>
+  </lexeme>
+  <lexeme>
+    <!-- Corrects over-long "aw" and under-emphasized "mut" -->
+    <grapheme>Shawmut</grapheme>
+    <phoneme>ʃɔmʌt</phoneme>
+  </lexeme>
+  <lexeme>
+    <!-- Moves emphasis to "Stony" from "Brook" -->
+    <grapheme>Stony Brook</grapheme>
+    <phoneme>ˌstonibrʊk</phoneme>
+  </lexeme>
+  <lexeme>
+    <grapheme>Wren St</grapheme>
+    <grapheme>Wren Street</grapheme>
+    <phoneme>ˈɹɛnˌstrit</phoneme>
+  </lexeme>
+
+  <!--=== Aliases ===-->
+
+  <lexeme>
+    <!-- Slows down pronunciation and puts emphasis in the right place -->
+    <grapheme>Longwood</grapheme>
+    <alias>Long Wood</alias>
+  </lexeme>
+  <lexeme>
+    <grapheme>mbta.com</grapheme>
+    <alias>MBTA dot com</alias>
+  </lexeme>
+  <lexeme>
+    <grapheme>mbta</grapheme>
+    <alias>MBTA</alias>
+  </lexeme>
+  <lexeme>
+    <!-- Prevents reading "Veterans' Affairs" as "Virginia" :facepalm: -->
+    <grapheme>VA</grapheme>
+    <alias>V.A.</alias>
+  </lexeme>
+
+  <!-- Don't say "slash" for "/" characters that are part of a station name -->
+  <lexeme>
+    <grapheme>Charles/MGH</grapheme>
+    <alias>Charles MGH</alias>
+  </lexeme>
+  <lexeme>
+    <grapheme>JFK/UMass</grapheme>
+    <alias>JFK UMass</alias>
+  </lexeme>
+  <lexeme>
+    <grapheme>Kendall/MIT</grapheme>
+    <alias>Kendall MIT</alias>
+  </lexeme>
+  <lexeme>
+    <grapheme>Medford/Tufts</grapheme>
+    <alias>Medford Tufts</alias>
+  </lexeme>
+  <lexeme>
+    <grapheme>Science Park/West End</grapheme>
+    <alias>Science Park West End</alias>
+  </lexeme>
+
+  <!-- Account for various contexts where "St" as an abbreviation for "Street"
+       is not pronounced correctly -->
   <lexeme>
     <grapheme>St &amp;</grapheme>
     <alias>Street and</alias>
@@ -28,101 +135,5 @@
   <lexeme>
     <grapheme>St)</grapheme>
     <alias>Street)</alias>
-  </lexeme>
-  <lexeme>
-    <grapheme>Avon</grapheme>
-    <phoneme>eɪvan</phoneme>
-  </lexeme>
-  <lexeme>
-    <grapheme>LaGrange</grapheme>
-    <phoneme>ˌləˈgɹanʒ</phoneme>
-  </lexeme>
-  <lexeme>
-    <grapheme>Wren St</grapheme>
-    <grapheme>Wren Street</grapheme>
-    <phoneme>ˈɹɛnˌstrit</phoneme>
-  </lexeme>
-  <lexeme>
-    <grapheme>Peabody</grapheme>
-    <phoneme>ˈpibədi</phoneme>
-  </lexeme>
-  <lexeme>
-    <grapheme>Hyannis</grapheme>
-    <phoneme>haɪ ˈænɪs</phoneme>
-  </lexeme>
-  <lexeme>
-    <grapheme>Chiswick</grapheme>
-    <phoneme>tʃɪz wɪk</phoneme>
-  </lexeme>
-  <lexeme>
-    <grapheme>Amory</grapheme>
-    <phoneme>ˈeɪməɹi</phoneme>
-  </lexeme>
-  <lexeme>
-    <grapheme>Fine Arts</grapheme>
-    <phoneme>faɪn aɹts</phoneme>
-  </lexeme>
-  <lexeme>
-    <!-- Prevents reading "Veterans' Affairs" as "Virginia" :facepalm: -->
-    <grapheme>VA</grapheme>
-    <alias>V.A.</alias>
-  </lexeme>
-  <lexeme>
-    <grapheme>mbta.com</grapheme>
-    <alias>MBTA dot com</alias>
-  </lexeme>
-  <lexeme>
-    <grapheme>mbta</grapheme>
-    <alias>MBTA</alias>
-  </lexeme>
-  <lexeme>
-    <!-- Slows down pronunciation and puts emphasis in the right place -->
-    <grapheme>Longwood</grapheme>
-    <alias>Long Wood</alias>
-  </lexeme>
-  <lexeme>
-    <!-- Corrects "Central Lavenue" pronunciation -->
-    <grapheme>Central Avenue</grapheme>
-    <phoneme>ˈsɛntɹl ˈævənu</phoneme>
-  </lexeme>
-  <lexeme>
-    <grapheme>Charles/MGH</grapheme>
-    <alias>Charles MGH</alias>
-  </lexeme>
-  <lexeme>
-    <grapheme>JFK/UMass</grapheme>
-    <alias>JFK UMass</alias>
-  </lexeme>
-  <lexeme>
-    <grapheme>Kendall/MIT</grapheme>
-    <alias>Kendall MIT</alias>
-  </lexeme>
-  <lexeme>
-    <grapheme>Science Park/West End</grapheme>
-    <alias>Science Park West End</alias>
-  </lexeme>
-  <lexeme>
-    <grapheme>Medford/Tufts</grapheme>
-    <alias>Medford Tufts</alias>
-  </lexeme>
-  <lexeme>
-    <!-- Moves emphasis to "Stony" from "Brook" -->
-    <grapheme>Stony Brook</grapheme>
-    <phoneme>ˌstonibrʊk</phoneme>
-  </lexeme>
-  <lexeme>
-    <!-- Moves emphasis to "Pack-" from "-ard" -->
-    <grapheme>Packard</grapheme>
-    <phoneme>ˈpækəɹd</phoneme>
-  </lexeme>
-  <lexeme>
-    <!-- Previous pronunciation sounded like "Fen-a-way" :thinkies: -->
-    <grapheme>Fenway</grapheme>
-    <phoneme>ˈfɛnweɪ</phoneme>
-  </lexeme>
-  <lexeme>
-    <!-- Corrects over-long "aw" and under-emphasized "mut" -->
-    <grapheme>Shawmut</grapheme>
-    <phoneme>ʃɔmʌt</phoneme>
   </lexeme>
 </lexicon>

--- a/mbtalexicon.pls
+++ b/mbtalexicon.pls
@@ -8,90 +8,83 @@
 
   <!--=== Phonemes ===-->
 
+  <!-- Guessing this sounds like "amorous" is reasonable but wrong -->
   <lexeme>
     <grapheme>Amory</grapheme>
     <phoneme>ˈeɪməɹi</phoneme>
   </lexeme>
+
+  <!-- Pronounce the "o" like in "on" rather than like a schwa -->
   <lexeme>
     <grapheme>Avon</grapheme>
-    <phoneme>eɪvan</phoneme>
+    <phoneme>ˈeɪvan</phoneme>
   </lexeme>
-  <lexeme>
-    <!-- Corrects "Central Lavenue" pronunciation -->
-    <grapheme>Central Avenue</grapheme>
-    <phoneme>ˈsɛntɹl ˈævənu</phoneme>
-  </lexeme>
+
+  <!-- Fix default pronunciation treating the "w" as silent -->
   <lexeme>
     <grapheme>Chiswick</grapheme>
-    <phoneme>tʃɪz wɪk</phoneme>
+    <phoneme>ˈtʃɪzwɪk</phoneme>
   </lexeme>
-  <lexeme>
-    <!-- Previous pronunciation sounded like "Fen-a-way" :thinkies: -->
-    <grapheme>Fenway</grapheme>
-    <phoneme>ˈfɛnweɪ</phoneme>
-  </lexeme>
+
+  <!-- Shorten gap between "Fine" and "Arts" -->
   <lexeme>
     <grapheme>Fine Arts</grapheme>
     <phoneme>faɪn aɹts</phoneme>
   </lexeme>
-  <lexeme>
-    <grapheme>Hyannis</grapheme>
-    <phoneme>haɪ ˈænɪs</phoneme>
-  </lexeme>
-  <lexeme>
-    <grapheme>LaGrange</grapheme>
-    <phoneme>ˌləˈgɹanʒ</phoneme>
-  </lexeme>
+
+  <!-- Pronounce "Lech" like "leach" instead of "leck" -->
   <lexeme>
     <grapheme>Lechmere</grapheme>
-    <phoneme>litʃ miɹ</phoneme>
+    <phoneme>ˈliːtʃmɪər</phoneme>
   </lexeme>
+
+  <!-- Pronounce "ard" with a schwa instead of like "arm" -->
   <lexeme>
-    <grapheme>Mattapan</grapheme>
-    <phoneme>mæɾ əˈpæn</phoneme>
-  </lexeme>
-  <lexeme>
-    <!-- Moves emphasis to "Pack-" from "-ard" -->
     <grapheme>Packard</grapheme>
     <phoneme>ˈpækəɹd</phoneme>
   </lexeme>
+
+  <!-- Pronounce "body" with a schwa instead of like the word "body" -->
   <lexeme>
     <grapheme>Peabody</grapheme>
-    <phoneme>ˈpibədi</phoneme>
+    <phoneme>ˈpiːbədi</phoneme>
   </lexeme>
+
+  <!-- Pronounce as one word with initial emphasis -->
   <lexeme>
-    <!-- Corrects over-long "aw" and under-emphasized "mut" -->
-    <grapheme>Shawmut</grapheme>
-    <phoneme>ʃɔmʌt</phoneme>
-  </lexeme>
-  <lexeme>
-    <!-- Moves emphasis to "Stony" from "Brook" -->
     <grapheme>Stony Brook</grapheme>
-    <phoneme>ˌstonibrʊk</phoneme>
-  </lexeme>
-  <lexeme>
-    <grapheme>Wren St</grapheme>
-    <grapheme>Wren Street</grapheme>
-    <phoneme>ˈɹɛnˌstrit</phoneme>
+    <phoneme>ˈstonibrʊk</phoneme>
   </lexeme>
 
   <!--=== Aliases ===-->
 
+  <!-- With confusing capitalization removed, this is correctly pronounced like
+       the French astronomer's name -->
   <lexeme>
-    <!-- Slows down pronunciation and puts emphasis in the right place -->
+    <grapheme>LaGrange</grapheme>
+    <alias>Lagrange</alias>
+  </lexeme>
+
+  <!-- Slow down pronunciation and put emphasis in the right place -->
+  <lexeme>
     <grapheme>Longwood</grapheme>
     <alias>Long Wood</alias>
   </lexeme>
+
+  <!-- Prevent ".com" from being read as an end-of-sentence and then "com" -->
   <lexeme>
     <grapheme>mbta.com</grapheme>
     <alias>MBTA dot com</alias>
   </lexeme>
+
+  <!-- Ensure MBTA is always read as an acronym and not a "word" -->
   <lexeme>
     <grapheme>mbta</grapheme>
     <alias>MBTA</alias>
   </lexeme>
+
+  <!-- Prevent reading the acronym for "Veterans' Affairs" as "Virginia" -->
   <lexeme>
-    <!-- Prevents reading "Veterans' Affairs" as "Virginia" :facepalm: -->
     <grapheme>VA</grapheme>
     <alias>V.A.</alias>
   </lexeme>


### PR DESCRIPTION
Prompted by an observation that our customized pronunciation of "Shawmut" was incorrect, and turned out to be correct by default when the customization was removed.

* Organize entries into "Phonemes" and "Aliases" sections, and (mostly) sort each section's entries by grapheme. (**Reviewer note:** this is a separate commit to reduce diff noise.)

* Remove custom pronunciations of "Central Avenue", "Fenway", "Hyannis", "Mattapan", "Shawmut", and "Wren Street". For these, the default Polly pronunciation is now equivalent or better.

* Replace custom phonemes for "LaGrange" with an alias to "Lagrange", which is pronounced correctly without needing to specify IPA.

* Improve stress and vowel sounds for "Avon", "Lechmere", "Peabody", and "Stony Brook".

* Comment all entries to clarify the purpose of each customization.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211123747782256