### PR TITLE
dev: update CODEOWNERS for new group name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mbta/digital-ride
+* @mbta/screens-developers


### PR DESCRIPTION
We missed this repo when `digital-ride` was renamed to `screens-developers`, so auto-review-requests were not working.