### PR TITLE
fix: remove now-unneeded Longwood fix

### DIFF
--- a/mbtalexicon.pls
+++ b/mbtalexicon.pls
@@ -65,12 +65,6 @@
     <alias>Lagrange</alias>
   </lexeme>
 
-  <!-- Slow down pronunciation and put emphasis in the right place -->
-  <lexeme>
-    <grapheme>Longwood</grapheme>
-    <alias>Long Wood</alias>
-  </lexeme>
-
   <!-- Prevent ".com" from being read as an end-of-sentence and then "com" -->
   <lexeme>
     <grapheme>mbta.com</grapheme>


### PR DESCRIPTION
The problem this was trying to fix seems to no longer exist, as both Standard and Neural engines now pronounce the un-aliased station name better than the "fixed" version.