### PR TITLE
chore: add zizmor to repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -7,20 +7,31 @@ on:
       - "**.pls"
       - ".github/**"
 
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   upload:
+    name: upload
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: read
+      contents: read # Needed to check out the repository
+      id-token: write # Needed to authenticate against AWS
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }} # zizmor: ignore[secrets-outside-env] - TODO: Move to a dedicated environment
           aws-region: us-east-1
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Upload lexicon
         run: |
-          aws polly put-lexicon --name mbtalexicon --content file://${{ github.workspace }}/mbtalexicon.pls
+          aws polly put-lexicon --name mbtalexicon --content file://"${GH_WORKSPACE}"/mbtalexicon.pls
+        env:
+          GH_WORKSPACE: ${{ github.workspace }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,21 +6,32 @@ on:
       - "**.pls"
       - ".github/**"
 
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
+    name: validate
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
     permissions:
-      id-token: write
-      contents: read
+      contents: read # Needed to check out the repository
+      id-token: write # Needed to authenticate against AWS
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }} # zizmor: ignore[secrets-outside-env] - TODO: Move to a dedicated environment
           aws-region: us-east-1
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Validate lexicon
         run: |
-          aws polly put-lexicon --name mbtalexiconvalidate --content file://${{ github.workspace }}/mbtalexicon.pls
+          aws polly put-lexicon --name mbtalexiconvalidate --content file://"${GH_WORKSPACE}"/mbtalexicon.pls
+        env:
+          GH_WORKSPACE: ${{ github.workspace }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: GitHub Actions Security Check
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    paths:
+      - '.github/**'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          advanced-security: false
+          persona: auditor


### PR DESCRIPTION
This commit adds zizmor to the repo. Doing so entails to components:
1. Adding a new workflow to run zizmor when workflow files are edited
2. Updating existing workflows to be compliant with the pedantic persona provided by zizmor

For this repository, the latter consisted of:
1. Pinning actions used. Most actions were up to date already, making this action largely a no-op. Version comment strings have been updated to ensure they do not use major version only tags (e.g. `v5`), as these can cause issues should the tag move to a new version.
2. Updating permissions so actions use have the least amount of permission when running
3. Justifying permissions via comments
4. Adding missing concurrency settings
5. Moving template expansions to environment variables to avoid potential injection issues
6. Setting an explicit cooldown period for dependabot